### PR TITLE
3709 avoid race condition which removes the valid locks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: ruby
 rvm:
   - 2.3.1
   - 2.2.5
-  - jruby-9.1.5.0
+  - jruby-9.2.8.0
 services:
   - redis-server

--- a/lib/sidekiq/extensions/queue.rb
+++ b/lib/sidekiq/extensions/queue.rb
@@ -14,7 +14,7 @@ module Sidekiq
       :probed,        :busy,
       :increase_busy, :decrease_busy,
       :local_busy?,   :explain,
-      :remove_locks_except!
+      :remove_locks_for!
 
     def lock
       @lock ||= LimitFetch::Global::Semaphore.new name

--- a/lib/sidekiq/limit_fetch/global/monitor.rb
+++ b/lib/sidekiq/limit_fetch/global/monitor.rb
@@ -8,14 +8,12 @@ module Sidekiq::LimitFetch::Global
     REFRESH_TIMEOUT = 5
 
     def start!(ttl=HEARTBEAT_TTL, timeout=REFRESH_TIMEOUT)
+      # We run this once syncronously so that callers can have more confidence
+      # that the current process is "valid."
+      run_limit_heartbeat ttl
       Thread.new do
         loop do
-          Sidekiq::LimitFetch.redis_retryable do
-            add_dynamic_queues
-            update_heartbeat ttl
-            invalidate_old_processes
-          end
-
+          run_limit_heartbeat ttl
           sleep timeout
         end
       end
@@ -32,9 +30,11 @@ module Sidekiq::LimitFetch::Global
     end
 
     def remove_old_processes!
+      processes_to_remove = old_processes
       Sidekiq.redis do |it|
-        old_processes.each {|process| it.srem PROCESS_SET, process }
+        processes_to_remove.each {|process| it.srem PROCESS_SET, process }
       end
+      processes_to_remove
     end
 
     def add_dynamic_queues
@@ -54,19 +54,46 @@ module Sidekiq::LimitFetch::Global
       end
     end
 
+    def note_current_probed_processes
+      # This method is necessary to avoid a situation where we remove a process "OLDP" from the PROCESS_SET
+      # but then our current process "CP" dies. Without this method, we would be stuck with some or all of OLDP's
+      # existing locks forever. However, this method re-adds "OLDP" to the PROCESS_SET to
+      # give us a chance to remove them if there is no heartbeat.
+      #
+      # This will not result in an infinite loop because the only thing that _adds_ process ids to the
+      # probed locks is actual work. So, eventually, we'll remove all the bad locks from the probed lists,
+      # and then remove those entries from the PROCESS_SET one last time.
+      Sidekiq.redis do |it|
+        current_probed_processes = Set.new
+        Sidekiq::Queue.instances.each do |queue|
+          current_probed_processes.merge(queue.lock.probed_processes)
+        end
+        it.sadd(PROCESS_SET, current_probed_processes.to_a) unless current_probed_processes.empty?
+      end
+    end
+
     def invalidate_old_processes
       Sidekiq.redis do |it|
-        remove_old_processes!
-        processes = all_processes
+        removed_old_processes = remove_old_processes!
 
         Sidekiq::Queue.instances.each do |queue|
-          queue.remove_locks_except! processes
+          queue.remove_locks_for! removed_old_processes
         end
       end
     end
 
     def heartbeat_key(process=Selector.uuid)
       HEARTBEAT_PREFIX + process
+    end
+
+    private
+    def run_limit_heartbeat(ttl)
+      Sidekiq::LimitFetch.redis_retryable do
+        add_dynamic_queues
+        update_heartbeat ttl
+        note_current_probed_processes
+        invalidate_old_processes
+      end
     end
   end
 end

--- a/lib/sidekiq/limit_fetch/global/semaphore.rb
+++ b/lib/sidekiq/limit_fetch/global/semaphore.rb
@@ -148,10 +148,9 @@ module Sidekiq::LimitFetch::Global
       END
     end
 
-    def remove_locks_except!(processes)
-      locked_processes = probed_processes.uniq
-      (locked_processes - processes).each do |dead_process|
-        remove_lock! dead_process
+    def remove_locks_for!(processes)
+      processes.each do |process|
+        remove_lock! process
       end
     end
 


### PR DESCRIPTION
In the monitor we load all processes and remove the process for which the
heartbeat is not set, then delete the lock for those invalid processes.

There is a race condition while deleting the invalid process that recently
started worker might get missed from all_process, which leads to deletion of its
lock. This will lead not respecting the limit since there is no lock for a
running worker.

trello - https://trello.com/c/g1CVYc1D/3709-sidekiq-not-respecting-limits-after-some-time
The changes are taken from PR https://github.com/apolloio/sidekiq-limit_fetch/pull/1/files