### PR TITLE
3709 reduce the chance of valid locks being removed

### DIFF
--- a/lib/sidekiq/limit_fetch/global/monitor.rb
+++ b/lib/sidekiq/limit_fetch/global/monitor.rb
@@ -4,8 +4,8 @@ module Sidekiq::LimitFetch::Global
 
     HEARTBEAT_PREFIX = 'limit:heartbeat:'
     PROCESS_SET = 'limit:processes'
-    HEARTBEAT_TTL = 20
-    REFRESH_TIMEOUT = 5
+    HEARTBEAT_TTL = 50
+    REFRESH_TIMEOUT = 4
 
     def start!(ttl=HEARTBEAT_TTL, timeout=REFRESH_TIMEOUT)
       # We run this once syncronously so that callers can have more confidence


### PR DESCRIPTION
The one way to reproduce limit not respecting issue in local was by keeping low
ttl for the heartbeat. 
So I am guessing the current ttl is not enough for long
running jobs. Increasing them and also decreasing refresh timeout to reduce the
chance of valid locks being removed.